### PR TITLE
Fix command used to copy files in linux and macOS

### DIFF
--- a/atomics/Indexes/index.yaml
+++ b/atomics/Indexes/index.yaml
@@ -4536,7 +4536,7 @@ persistence:
         name: sh
         elevation_required: true
         command: |
-          copy #{payload} /tmp/hello.c
+          cp #{payload} /tmp/hello.c
           cd /tmp
           sudo chown root hello.c
           sudo make hello
@@ -15583,7 +15583,7 @@ privilege-escalation:
         name: sh
         elevation_required: true
         command: |
-          copy #{payload} /tmp/hello.c
+          cp #{payload} /tmp/hello.c
           cd /tmp
           sudo chown root hello.c
           sudo make hello

--- a/atomics/T1166/T1166.md
+++ b/atomics/T1166/T1166.md
@@ -33,7 +33,7 @@ Make, change owner, and change file attributes on a C source code file
 
 
 ```sh
-copy #{payload} /tmp/hello.c
+cp #{payload} /tmp/hello.c
 cd /tmp
 sudo chown root hello.c
 sudo make hello

--- a/atomics/T1166/T1166.yaml
+++ b/atomics/T1166/T1166.yaml
@@ -21,7 +21,7 @@ atomic_tests:
     name: sh
     elevation_required: true
     command: |
-      copy #{payload} /tmp/hello.c
+      cp #{payload} /tmp/hello.c
       cd /tmp
       sudo chown root hello.c
       sudo make hello


### PR DESCRIPTION
**Details**
The command copy is used on Windows systems. Running the test on macOS and Linux will cause an error because copy doesn't exist.

**Testing**
Run the test in interactive mode.

**Associated Issues**
None